### PR TITLE
Feature/comment

### DIFF
--- a/src/main/java/com/tmproject/api/comment/controller/CommentController.java
+++ b/src/main/java/com/tmproject/api/comment/controller/CommentController.java
@@ -1,0 +1,38 @@
+package com.tmproject.api.comment.controller;
+
+import com.tmproject.api.comment.dto.CommentRequestDto;
+import com.tmproject.api.comment.service.CommentService;
+import com.tmproject.global.common.ApiResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/member/comments")
+public class CommentController {
+
+    @Autowired
+    private CommentService commentService;
+
+    @PostMapping("/{boardId}")
+    public ResponseEntity<ApiResponseDto> createComment(@PathVariable Long boardId, @RequestBody CommentRequestDto requestDto) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        ApiResponseDto response = commentService.createComment(boardId, requestDto, username);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<ApiResponseDto> updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto requestDto) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        ApiResponseDto response = commentService.updateComment(commentId, requestDto, username);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponseDto> deleteComment(@PathVariable Long commentId) {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        ApiResponseDto response = commentService.deleteComment(commentId, username);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/dto/CommentListDto.java
+++ b/src/main/java/com/tmproject/api/comment/dto/CommentListDto.java
@@ -1,0 +1,16 @@
+package com.tmproject.api.comment.dto;
+
+import java.util.List;
+import com.tmproject.api.comment.entity.Comment;
+
+public class CommentListDto {
+    private List<Comment> comments;
+
+    public List<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/tmproject/api/comment/dto/CommentRequestDto.java
@@ -1,0 +1,14 @@
+package com.tmproject.api.comment.dto;
+
+
+public class CommentRequestDto {
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/tmproject/api/comment/dto/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package com.tmproject.api.comment.dto;
+
+
+import com.tmproject.api.comment.entity.Comment;
+import com.tmproject.global.common.ApiResponseDto;
+
+public class CommentResponseDto extends ApiResponseDto {
+
+    public CommentResponseDto(String message, int statusCode, Comment commentData) {
+        super(message, statusCode, commentData);
+    }
+    public Comment getCommentData() {
+        return (Comment) super.getData();
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/entity/Comment.java
+++ b/src/main/java/com/tmproject/api/comment/entity/Comment.java
@@ -1,0 +1,62 @@
+package com.tmproject.api.comment.entity;
+
+import com.tmproject.api.member.entity.Member;
+import com.tmproject.api.board.entity.Board;
+import com.tmproject.global.common.Timestamped;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Comment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member; // 댓글 작성자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board; // 댓글이 달린 게시물
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public Board getBoard() {
+        return board;
+    }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/tmproject/api/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.tmproject.api.comment.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class CommentNotFoundException extends RuntimeException {
+
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tmproject/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tmproject/api/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.tmproject.api.comment.repository;
+
+import com.tmproject.api.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/tmproject/api/comment/service/CommentService.java
+++ b/src/main/java/com/tmproject/api/comment/service/CommentService.java
@@ -1,0 +1,62 @@
+package com.tmproject.api.comment.service;
+
+import com.tmproject.api.board.entity.Board;
+import com.tmproject.api.board.repository.BoardRepository;
+import com.tmproject.api.comment.dto.CommentRequestDto;
+import com.tmproject.api.comment.dto.CommentResponseDto;
+import com.tmproject.api.comment.entity.Comment;
+import com.tmproject.api.comment.exception.CommentNotFoundException;
+import com.tmproject.api.comment.repository.CommentRepository;
+import com.tmproject.api.member.entity.Member;
+import com.tmproject.api.member.repository.MemberRepository;
+import com.tmproject.global.common.ApiResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommentService {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    public ApiResponseDto createComment(Long boardId, CommentRequestDto requestDto, String username) {
+        Board board = boardRepository.findById(boardId).orElseThrow(() -> new RuntimeException("Board not found"));
+        Member member = memberRepository.findByUsername(username).orElseThrow(() -> new RuntimeException("Member not found"));
+
+        Comment comment = Comment.builder()
+                .content(requestDto.getContent())
+                .member(member)
+                .board(board)
+                .build();
+
+        commentRepository.save(comment);
+        return new CommentResponseDto("댓글 작성 성공", 200, comment);
+    }
+
+    public ApiResponseDto updateComment(Long commentId, CommentRequestDto requestDto, String username) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentNotFoundException("Comment not found"));
+        if (!comment.getMember().getUsername().equals(username)) {
+            throw new IllegalArgumentException("No permission to update this comment");
+        }
+
+        comment.setContent(requestDto.getContent());
+        commentRepository.save(comment);
+        return new CommentResponseDto("댓글 수정 성공", 200, comment);
+    }
+
+    public ApiResponseDto deleteComment(Long commentId, String username) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentNotFoundException("Comment not found"));
+        if (!comment.getMember().getUsername().equals(username)) {
+            throw new IllegalArgumentException("No permission to delete this comment");
+        }
+
+        commentRepository.delete(comment);
+        return new CommentResponseDto("댓글 삭제 성공", 200, null);
+    }
+}

--- a/src/main/java/com/tmproject/global/common/ApiResponseDto.java
+++ b/src/main/java/com/tmproject/global/common/ApiResponseDto.java
@@ -1,0 +1,22 @@
+package com.tmproject.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL) // null이 아닌 필드만 JSON에 포함
+public class ApiResponseDto<T> {
+    private String msg;
+    private Integer statusCode;
+    private T data; // 일반화된 데이터 필드
+
+    public ApiResponseDto(String msg, Integer statusCode, T data) {
+        this.msg = msg;
+        this.statusCode = statusCode;
+        this.data = data;
+    }
+}


### PR DESCRIPTION
1. 댓글 엔티티 추가
댓글 기능을 위한 Comment 엔티티 클래스를 추가 댓글의 내용, 작성자, 해당 게시글 정보를 저장
2. 댓글 리포지토리 추가
CommentRepository 인터페이스를 추가하여 댓글 데이터에 대한 JPA 기반 CRUD 작업을 지원
3. 댓글 서비스 로직 구현
CommentService에 댓글 작성, 조회, 수정, 삭제 기능을 구현 댓글 관련 비즈니스 로직
4. 댓글 컨트롤러 구현
 CommentController를 추가하여 댓글 관련 HTTP 요청을 처리 컨트롤러는 댓글 작성, 조회, 수정, 삭제 
5. 댓글 DTO 클래스 추가
댓글 기능에 필요한 데이터 전송 객체(DTO)들을 추가 CommentRequestDto, CommentResponseDto 
6. 댓글 관련 예외 처리 추가
댓글 기능에서 발생할 수 있는 예외 상황을 처리하기 위한 사용자 정의 예외 클래스를 추가