### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/com/tmproject/Common/Jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/tmproject/Common/Jwt/JwtAuthorizationFilter.java
@@ -60,13 +60,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         Authentication authentication = createAuthentication(username);
         context.setAuthentication(authentication);
 
-        SecurityContextHolder.setContext(context);
-    }
+            SecurityContextHolder.setContext(context);
+        }
 
     // 인증 객체 생성
     private Authentication createAuthentication(String username) {
         log.info("createAuthentication()");
         UserDetails userDetails = memberDetailsService.loadUserByUsername(username);
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/com/tmproject/Common/Security/MemberDetailsImpl.java
+++ b/src/main/java/com/tmproject/Common/Security/MemberDetailsImpl.java
@@ -3,6 +3,7 @@ package com.tmproject.Common.Security;
 
 import com.tmproject.api.member.entity.Member;
 import com.tmproject.api.member.entity.MemberRoleEnum;
+import lombok.Builder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@Builder
 public class MemberDetailsImpl implements UserDetails {
 
     private Member member;

--- a/src/main/java/com/tmproject/Common/Security/MemberDetailsServiceImpl.java
+++ b/src/main/java/com/tmproject/Common/Security/MemberDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.tmproject.Common.Security;
 
+
 import com.tmproject.api.member.entity.Member;
 import com.tmproject.api.member.repository.MemberRepository;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,10 +17,11 @@ public class MemberDetailsServiceImpl implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Member member = memberRepository.findByUsername(username).orElseThrow(
-                ()-> new UsernameNotFoundException("해당 유저 네임을 찾을 수 없습니다.")
+    public UserDetails loadUserByUsername(String usernameOrEmail) throws UsernameNotFoundException {
+        Member member = memberRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail).orElseThrow(
+                () -> new UsernameNotFoundException("Not Found " + usernameOrEmail)
         );
+
         return new MemberDetailsImpl(member);
     }
 }

--- a/src/main/java/com/tmproject/api/member/controller/MemberController.java
+++ b/src/main/java/com/tmproject/api/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.tmproject.Common.Security.MemberDetailsImpl;
 import com.tmproject.api.member.dto.ProfileResponseDto;
 import com.tmproject.api.member.dto.ProfileUpdateRequestDto;
 import com.tmproject.api.member.dto.SignupRequestDto;
+import com.tmproject.api.member.entity.Member;
 import com.tmproject.api.member.service.MemberService;
 import com.tmproject.global.common.ApiResponseDto;
 import jakarta.validation.Valid;
@@ -33,7 +34,7 @@ public class MemberController {
             }
         }
         ApiResponseDto<?> apiResponseDto = memberService.signup(requestDto);
-        return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.valueOf(apiResponseDto.getStatusCode()));
         // SignupDto 제약 조건 확인
     }
 
@@ -41,9 +42,10 @@ public class MemberController {
     @PutMapping("/profile/{memberId}")
     public ResponseEntity<ApiResponseDto<?>> updateProfile(
             @PathVariable long memberId,
-            @RequestBody ProfileUpdateRequestDto requestDto){
-        ApiResponseDto<?> apiResponseDto = memberService.updateMember(memberId, requestDto);
-        return new ResponseEntity<>(apiResponseDto , HttpStatus.OK);
+            @RequestBody ProfileUpdateRequestDto requestDto,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails){
+        ApiResponseDto<?> apiResponseDto = memberService.updateMember(memberId, requestDto, memberDetails);
+        return new ResponseEntity<>(apiResponseDto , HttpStatus.valueOf(apiResponseDto.getStatusCode()));
     }
 
     @PutMapping("/profile/{memberId}/profileImageUrl")
@@ -52,14 +54,15 @@ public class MemberController {
             @RequestPart MultipartFile profileImage,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails){
         ApiResponseDto<?> apiResponseDto = memberService.updateMemberProfileImage(memberId, profileImage, memberDetails);
-        return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.valueOf(apiResponseDto.getStatusCode()));
     }
 
     @GetMapping("/profile/{memberId}")
     public ResponseEntity<ApiResponseDto<ProfileResponseDto>> getMemberInfo(
-            @PathVariable long memberId){
-        ApiResponseDto<ProfileResponseDto> responseDto = memberService.getMemberInfo(memberId);
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+            @PathVariable long memberId,
+            @AuthenticationPrincipal MemberDetailsImpl memberDetails){
+        ApiResponseDto<ProfileResponseDto> apiResponseDto = memberService.getMemberInfo(memberId, memberDetails);
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.valueOf(apiResponseDto.getStatusCode()));
     }
     // 자기 자신의 정보를 확인할 수 있는 메서드
     // 자기 자신이 아닌 다른 사람도 확인이 가능해야함

--- a/src/main/java/com/tmproject/api/member/controller/MemberController.java
+++ b/src/main/java/com/tmproject/api/member/controller/MemberController.java
@@ -1,22 +1,17 @@
 package com.tmproject.api.member.controller;
 
 import com.tmproject.Common.Security.MemberDetailsImpl;
-import com.tmproject.api.member.dto.ProfileRequestDto;
+import com.tmproject.api.member.dto.ProfileResponseDto;
+import com.tmproject.api.member.dto.ProfileUpdateRequestDto;
 import com.tmproject.api.member.dto.SignupRequestDto;
-import com.tmproject.api.member.entity.Member;
 import com.tmproject.api.member.service.MemberService;
 import com.tmproject.global.common.ApiResponseDto;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -37,8 +32,8 @@ public class MemberController {
                 return new ResponseEntity<>(new ApiResponseDto<>("회원 가입 요청 실패", 400, error.getDefaultMessage()),HttpStatus.BAD_REQUEST);
             }
         }
-        memberService.signup(requestDto);
-        return new ResponseEntity<>(new ApiResponseDto<>("회원 가입 요청 성공", 200, null),HttpStatus.OK);
+        ApiResponseDto<?> apiResponseDto = memberService.signup(requestDto);
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
         // SignupDto 제약 조건 확인
     }
 
@@ -46,9 +41,9 @@ public class MemberController {
     @PutMapping("/profile/{memberId}")
     public ResponseEntity<ApiResponseDto<?>> updateProfile(
             @PathVariable long memberId,
-            @RequestBody ProfileRequestDto requestDto){
-            memberService.updateMember(memberId, requestDto);
-        return new ResponseEntity<>(new ApiResponseDto<>("유저 프로필 수정 성공", 200, null), HttpStatus.OK);
+            @RequestBody ProfileUpdateRequestDto requestDto){
+        ApiResponseDto<?> apiResponseDto = memberService.updateMember(memberId, requestDto);
+        return new ResponseEntity<>(apiResponseDto , HttpStatus.OK);
     }
 
     @PutMapping("/profile/{memberId}/profileImageUrl")
@@ -56,7 +51,16 @@ public class MemberController {
             @PathVariable long memberId,
             @RequestPart MultipartFile profileImage,
             @AuthenticationPrincipal MemberDetailsImpl memberDetails){
-        memberService.updateMemberProfileImage(memberId, profileImage, memberDetails);
-        return new ResponseEntity<>(new ApiResponseDto<>("회원 프로필 사진 변경 성공",200,null),HttpStatus.OK);
+        ApiResponseDto<?> apiResponseDto = memberService.updateMemberProfileImage(memberId, profileImage, memberDetails);
+        return new ResponseEntity<>(apiResponseDto, HttpStatus.OK);
     }
+
+    @GetMapping("/profile/{memberId}")
+    public ResponseEntity<ApiResponseDto<ProfileResponseDto>> getMemberInfo(
+            @PathVariable long memberId){
+        ApiResponseDto<ProfileResponseDto> responseDto = memberService.getMemberInfo(memberId);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+    // 자기 자신의 정보를 확인할 수 있는 메서드
+    // 자기 자신이 아닌 다른 사람도 확인이 가능해야함
 }

--- a/src/main/java/com/tmproject/api/member/dto/ProfileResponseDto.java
+++ b/src/main/java/com/tmproject/api/member/dto/ProfileResponseDto.java
@@ -1,0 +1,12 @@
+package com.tmproject.api.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ProfileResponseDto {
+    private String username;
+    private String introduction;
+
+}

--- a/src/main/java/com/tmproject/api/member/dto/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/tmproject/api/member/dto/ProfileUpdateRequestDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
-public class ProfileRequestDto {
+public class ProfileUpdateRequestDto {
 
     @NotBlank
     private String username;

--- a/src/main/java/com/tmproject/api/member/entity/Member.java
+++ b/src/main/java/com/tmproject/api/member/entity/Member.java
@@ -11,6 +11,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder

--- a/src/main/java/com/tmproject/api/member/entity/Member.java
+++ b/src/main/java/com/tmproject/api/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.tmproject.api.member.entity;
 
-import com.tmproject.api.member.dto.ProfileRequestDto;
+import com.tmproject.api.member.dto.ProfileResponseDto;
+import com.tmproject.api.member.dto.ProfileUpdateRequestDto;
 import com.tmproject.global.common.Timestamped;
 import jakarta.persistence.*;
 
@@ -55,7 +56,7 @@ public class Member extends Timestamped {
         this.role = role;
         // 기본 정보 저장
     }
-    public void update(ProfileRequestDto profileRequestDto, String encodedPassowrd){
+    public void update(ProfileUpdateRequestDto profileRequestDto, String encodedPassowrd){
         this.username = profileRequestDto.getUsername();
         this.password = encodedPassowrd;
         this.email = profileRequestDto.getEmail();
@@ -65,7 +66,6 @@ public class Member extends Timestamped {
 
     public void updateProfileImageUrl(String profileImageUrl){
         this.profileImageUrl = profileImageUrl;
-        // 이거 임시일듯? 잠시,,, 테스트좀 해봐야해
     }
-    // 따로 이미지파일url 변경 로직도 필요할듯?
+
 }

--- a/src/main/java/com/tmproject/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/tmproject/api/member/repository/MemberRepository.java
@@ -10,4 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
+    boolean existsByEmailAndIdNot(String requestEmail, long memberId);
+    boolean existsByUsernameAndIdNot(String username, long memberId);
+    Optional<Member> findByUsernameOrEmail(String usernameOrEmail, String usernameOrEmail1);
 }

--- a/src/main/java/com/tmproject/api/member/service/MemberService.java
+++ b/src/main/java/com/tmproject/api/member/service/MemberService.java
@@ -20,8 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -41,6 +40,8 @@ public class MemberService {
     private String uploadFolder;
     // cloud 굳이 쓸 필요 없다
     // cloud 시간 남으면 해보자
+
+    private static Stack<String> passwordHistory = new Stack<>();
 
     @PostConstruct
     public void createAdminAccount(){
@@ -63,15 +64,17 @@ public class MemberService {
 
         Optional<Member> checkUsername = memberRepository.findByUsername(username);
         if(checkUsername.isPresent()){
-            throw new IllegalArgumentException("중복된 사용자가 존재합니다.");
+            return new ApiResponseDto<>("중복된 사용자가 존재합니다.", 400, null);
         }
         String rawPassword = requestDto.getPassword();
         String encodedPassword = passwordEncoder.encode(rawPassword);
         String email = requestDto.getEmail();
         Optional<Member> checkEmail = memberRepository.findByEmail(email);
+
         if (checkEmail.isPresent()) {
-            throw new IllegalArgumentException("중복된 Email 입니다.");
+            return new ApiResponseDto<>("중복된 Email이 존재합니다.", 400, null);
         }
+        // 회원 가입을 할 때는 중복 Email불가
 
         Member member = Member.builder()
                 .username(username)
@@ -85,32 +88,80 @@ public class MemberService {
     }
 
     @Transactional
-    public ApiResponseDto<?> updateMember(long memberId, ProfileUpdateRequestDto requestDto){
+    public ApiResponseDto<?> updateMember(long memberId, ProfileUpdateRequestDto requestDto, MemberDetailsImpl memberDetails){
         Member memberEntity = memberRepository.findById(memberId).orElseThrow(
                 ()-> new IllegalArgumentException("해당 id는 존재하지 않습니다.")
         );
+        if(!memberDetails.getUsername().equals(requestDto.getUsername())){
+            return new ApiResponseDto<>("유저 네임은 변경할 수 없습니다.", 400, null);
+        }
+        if (memberRepository.existsByUsernameAndIdNot(requestDto.getUsername(), memberId)) {
+            return new ApiResponseDto<>("이미 사용 중인 유저 네임입니다.", 400, null);
+        }
+
+        if (memberDetails.getMember().getId() != memberId) {
+            // id 1번은 무조건 관리자 아이디이기에
+            return new ApiResponseDto<>("해당 사용자는 권한이 없습니다.", 403, null);
+        }
 
         if(!requestDto.getPasswordConfirm().equals(requestDto.getPassword())){
-            throw new IllegalArgumentException("1차 비밀번호와 2차 비밀번호가 다릅니다.");
+            return new ApiResponseDto<>("1차 비밀번호와 2차 비밀번호가 다릅니다.", 400, null);
         }
 
-        if (memberRepository.existsByEmail(requestDto.getEmail())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        String requestEmail = requestDto.getEmail();
+        log.info("requestEmail : "+ requestEmail);
+        log.info("memberEntity.getEmail() : "+memberEntity.getEmail());
+        System.out.println("requestEmail.equals(memberEntity.getEmail()) : "+requestEmail.equals(memberEntity.getEmail()));
+        System.out.println("memberRepository.existsByEmail(requestEmail) : "+memberRepository.existsByEmail(requestEmail));
+
+        if (memberRepository.existsByEmailAndIdNot(requestEmail, memberId)) {
+            return new ApiResponseDto<>("이미 사용 중인 이메일입니다.", 400, null);
         }
-        // 이메일 중복 검증
+        // 이메일 중복 검증 확인 amdin email과 member email 검증
+
+        if (!isPasswordAllowed(requestDto.getPassword())) {
+            return new ApiResponseDto<>("해당 비밀번호는 최근 3번 안에 사용한 비밀번호이기에 사용할 수 없습니다.", 400, null);
+        }
+        // 새 비밀번호가 마지막 세 개의 비밀번호 중 하나와 일치하는지 확인
+
+        passwordHistory.push(requestDto.getPassword());
+        log.info("passwordHistory.size() : "+passwordHistory.size());
+        // 새 비밀번호를 스택에 추가
 
         String encodedPassowrd = passwordEncoder.encode(requestDto.getPassword());
-
-        // 최근 3번안에 사용한 비밀번호는 사용할 수 없도록 제한합니다.
-        // 해당 사항 만들기
 
         memberEntity.update(requestDto, encodedPassowrd);
         memberRepository.save(memberEntity);
         return new ApiResponseDto<>("유저 프로필 수정 성공",200,null);
     }
 
+    private boolean isPasswordAllowed(String newPassword) {
+        if (passwordHistory.size() >= 3) {
+            // passwordHistory가 3개 이상인 경우
+            String firstElement = passwordHistory.pop();
+            boolean allEqual = passwordHistory.stream().allMatch(element -> element.equals(firstElement));
+
+            // passwordHistory를 다시 되돌려놓음
+            passwordHistory.push(firstElement);
+
+            return !allEqual;
+        }
+        // passwordHistory가 3개 미만인 경우는 모두 허용
+        return true;
+    }
+
     @Transactional
     public ApiResponseDto<?> updateMemberProfileImage(long memberId, MultipartFile imageFile, MemberDetailsImpl memberDetails) {
+        Member memberEntity = memberRepository.findById(memberId).orElseThrow(
+                ()-> new IllegalArgumentException("해당 유저는 존재하지 않습니다.")
+        );
+        log.info("memberId : "+memberId);
+        log.info("memberDetails.getMember().getId() : "+memberDetails.getMember().getId());
+        if (memberDetails.getMember().getId() != memberId) {
+            // id 1번은 무조건 관리자 아이디이기에
+            return new ApiResponseDto<>("해당 사용자는 권한이 없습니다.", 403, null);
+        }
+
         UUID uuid = UUID.randomUUID();
         // image파일 이름의 중복을 방지하기 위해 uuid사용
         String uuidImage = uuid+"_"+imageFile.getOriginalFilename();
@@ -125,9 +176,6 @@ public class MemberService {
             e.printStackTrace();
         }
 
-        Member memberEntity = memberRepository.findById(memberId).orElseThrow(
-                ()-> new IllegalArgumentException("해당 유저는 존재하지 않습니다.")
-        );
         String testImageFilePath = imageFilePath.toString();
         log.info("testImageFilePath : "+testImageFilePath);
 
@@ -136,13 +184,29 @@ public class MemberService {
         return new ApiResponseDto<>("회원 프로필 사진 변경 성공",200,null);
     }
 
-    public ApiResponseDto<ProfileResponseDto> getMemberInfo(long memberId) {
+    public ApiResponseDto<ProfileResponseDto> getMemberInfo(long memberId, MemberDetailsImpl memberDetails) {
+        log.info("memberId : "+memberId);
+        // 지금 조회하려는 memberId
+        log.info("member.getMember().getId() : "+ memberDetails.getMember().getId());
+        // 로그인한 맴버 아이디
+        log.info("member.getMember().getUsername() : "+ memberDetails.getMember().getUsername());
+        log.info("memberDetails.getMember().getUsername().equals(\"root\") && memberDetails.getMember().getId() != 1L" +
+                (memberDetails.getMember().getUsername().equals("root") && memberDetails.getMember().getId() != 1L));
+        /*if(!memberDetails.getMember().getUsername().equals("root") && memberDetails.getMember().getId() != 1L){
+            // 로그인 사용자의 유저네임 : park -> root와 다름 -> true, memberDetails.getMember().getId() != 1L, 로그인한 사용자는 지금 park -> true
+            // 로그인 사용자의 유저네임 : park -> root와 다름 -> true, memberDetails.getMember().getId() != 1L, 로그인한 사용자는 지금 park -> true
+            return new ApiResponseDto<>("해당 유저는 접근 권한이 없습니다.",403,null);
+        }*/
+        if(memberDetails.getMember().getId() != 1L && memberId == 1L){
+            return new ApiResponseDto<>("해당 유저는 접근 권한이 없습니다.",403,null);
+        }
         Member member = memberRepository.findById(memberId).orElseThrow(
                 ()-> new IllegalArgumentException("해당하는 Member Id는 존재하지 않습니다.")
         );
         ProfileResponseDto profileResponseDto = new ProfileResponseDto(member.getUsername(), member.getIntroduction());
         log.info("profileResponseDto.getUsername() : "+profileResponseDto.getUsername());
         log.info("profileResponseDto.getIntroduction() : "+profileResponseDto.getIntroduction());
+        // 관리자의 정보는 못보게 해야하나?
         return new ApiResponseDto<>("해당 유저 정보 조회 성공",200, profileResponseDto);
     }
 }


### PR DESCRIPTION
feat : getMemberInfo() : 해당 멤버의 프로필의 정보 열람 가능한 메서드 구현
fix : MemberService updateMember() : 비지니스 로직 : '최근 3번 안에 사용한 비밀번호는 사용할 수 없도록 제한합니다.', '유저 네임 바꿀 수 없습니다.' 수정